### PR TITLE
Change contrast for the purple backgroundfrom black to white 

### DIFF
--- a/Lovely Dashboard/JavascriptExtensions/Lovely-Dashboard_extensions.js
+++ b/Lovely Dashboard/JavascriptExtensions/Lovely-Dashboard_extensions.js
@@ -487,8 +487,19 @@ function ld_getEstimatedTextColour() {
     } else {
 
         if ( $prop('DataCorePlugin.GameRawData.Graphics.isValidLap') == 1 ) {
+            
+	        if ( timeDiffMine == null & timeDiffOverall == null) {
+                return black // white bg
+            } else if ( timeDiffMine > 0 ) {
+                return black // yellow bg
+            } else {
+                if ( timeDiffOverall > 0 ) {
+                    return white // green bg
+                } else {
+                    return black // purple bg
+                }
+            }
 
-            return black
 
         } else {
             return white // red bg


### PR DESCRIPTION
To increase the contrast ratio from 4.26 to  4.92 I propose to have a white text instead of a black one for the delta time : 

before : 

![image](https://github.com/cdemetriadis/lovely-dashboard/assets/5020806/c5f68ebb-5fb1-4951-8461-7aa8e59f24e5)

after : 

![image](https://github.com/cdemetriadis/lovely-dashboard/assets/5020806/e1c0e32c-6871-403c-8836-f2ca89072c74)
