### PR TITLE
Be able to select which CentralMFM you have in the rotation

### DIFF
--- a/Lovely Dashboard/Central.djson
+++ b/Lovely Dashboard/Central.djson
@@ -18,7 +18,7 @@
   "ForegroundOpacity": 100.0,
   "GridSize": 10,
   "HideLabels": true,
-  "Id": "45f344ca-3e8b-499f-ab1a-61525a2b89dc",
+  "Id": "ddc92461-6e77-4158-b046-a5d39a7887aa",
   "Images": [],
   "IsOverlay": false,
   "Metadata": {
@@ -3117,7 +3117,8 @@
       },
       "PitScreen": false,
       "ScreenEnabledExpression": {
-        "Expression": ""
+        "Expression": "const json_settings = readtextfile('./JavascriptExtensions/Lovely-Dashboard_settings.json')\r\nconst settings = JSON.parse(json_settings);\r\n\r\nconst currentSim = ld_getSim()\r\n\t\r\nif ( settings ) {\r\n\r\n\r\n\tactiveMFM = eval(\"settings.\"+currentSim+\".activeCentralMFM\").trim()\r\n\t\r\n\tif ( !activeMFM || activeMFM == \"\" ) {\r\n\t\t// Show MFM if no activeMFM has been set\r\n\t\treturn true\r\n\t} else {\r\n\t\t// Is MFM set in activeMFM?\r\n\t\treturn activeMFM.includes(0)\r\n\t}\r\n\t\r\n} else {\r\n\r\n\treturn true \r\n\r\n}",
+        "Interpreter": 1
       },
       "ScreenId": "6e12babf-9d62-43f0-90b9-769fc77341d2"
     },
@@ -4884,7 +4885,8 @@
       },
       "PitScreen": false,
       "ScreenEnabledExpression": {
-        "Expression": ""
+        "Expression": "const json_settings = readtextfile('./JavascriptExtensions/Lovely-Dashboard_settings.json')\r\nconst settings = JSON.parse(json_settings);\r\n\r\nconst currentSim = ld_getSim()\r\n\t\r\nif ( settings ) {\r\n\r\n\r\n\tactiveMFM = eval(\"settings.\"+currentSim+\".activeCentralMFM\").trim()\r\n\t\r\n\tif ( !activeMFM || activeMFM == \"\" ) {\r\n\t\t// Show MFM if no activeMFM has been set\r\n\t\treturn true\r\n\t} else {\r\n\t\t// Is MFM set in activeMFM?\r\n\t\treturn activeMFM.includes(1)\r\n\t}\r\n\t\r\n} else {\r\n\r\n\treturn true \r\n\r\n}",
+        "Interpreter": 1
       },
       "ScreenId": "89dd15fa-4877-4545-9847-52b893d2ed5d"
     },
@@ -6917,7 +6919,8 @@
       },
       "PitScreen": false,
       "ScreenEnabledExpression": {
-        "Expression": ""
+        "Expression": "const json_settings = readtextfile('./JavascriptExtensions/Lovely-Dashboard_settings.json')\r\nconst settings = JSON.parse(json_settings);\r\n\r\nconst currentSim = ld_getSim()\r\n\t\r\nif ( settings ) {\r\n\r\n\r\n\tactiveMFM = eval(\"settings.\"+currentSim+\".activeCentralMFM\").trim()\r\n\t\r\n\tif ( !activeMFM || activeMFM == \"\" ) {\r\n\t\t// Show MFM if no activeMFM has been set\r\n\t\treturn true\r\n\t} else {\r\n\t\t// Is MFM set in activeMFM?\r\n\t\treturn activeMFM.includes(2)\r\n\t}\r\n\t\r\n} else {\r\n\r\n\treturn true \r\n\r\n}",
+        "Interpreter": 1
       },
       "ScreenId": "44cc1147-a7bd-4752-ac3a-822a0b5a2ed6"
     },
@@ -9974,7 +9977,8 @@
       },
       "PitScreen": false,
       "ScreenEnabledExpression": {
-        "Expression": ""
+        "Expression": "const json_settings = readtextfile('./JavascriptExtensions/Lovely-Dashboard_settings.json')\r\nconst settings = JSON.parse(json_settings);\r\n\r\nconst currentSim = ld_getSim()\r\n\t\r\nif ( settings ) {\r\n\r\n\r\n\tactiveMFM = eval(\"settings.\"+currentSim+\".activeCentralMFM\").trim()\r\n\t\r\n\tif ( !activeMFM || activeMFM == \"\" ) {\r\n\t\t// Show MFM if no activeMFM has been set\r\n\t\treturn true\r\n\t} else {\r\n\t\t// Is MFM set in activeMFM?\r\n\t\treturn activeMFM.includes(3)\r\n\t}\r\n\t\r\n} else {\r\n\r\n\treturn true \r\n\r\n}",
+        "Interpreter": 1
       },
       "ScreenId": "d4dad73d-ae8f-4f74-ae8a-25854d219624"
     }

--- a/Lovely-Dashboard_settings.json
+++ b/Lovely-Dashboard_settings.json
@@ -94,7 +94,7 @@
             "activeRightMFM_help": "4,5,6,8 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
 
         "activeCentralMFM": "",
-            "activeCentralMFM_help": "0,1,2 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+            "activeCentralMFM_help": "0,1,2,3 - Select which available MFMs to activate in the Dashboard - Leave blank for all, 0: Quali, 1: Race, 2: PC Time, 3: Speedometer",
 
         "leftMFM": 4,
             "leftMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 6: Damage, 8: Map, 9: Opponents",
@@ -122,7 +122,7 @@
             "activeRightMFM_help": "4,5,6,8 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
 
         "activeCentralMFM": "",
-            "activeCentralMFM_help": "0,1,2 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+        "activeCentralMFM_help": "0,1,2,3 - Select which available MFMs to activate in the Dashboard - Leave blank for all, 0: Quali, 1: Race, 2: PC Time, 3: Speedometer",
 
         "leftMFM": 4,
             "leftMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 6: Damage, 8: Map, 9: Opponents",
@@ -150,7 +150,7 @@
             "activeRightMFM_help": "4,7,8 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
  
         "activeCentralMFM": "",
-            "activeCentralMFM_help": "0,1,2 - Select which available MFMs to activate in the Dashboard - Leave blank for all",  
+            "activeCentralMFM_help": "0,1,2,3 - Select which available MFMs to activate in the Dashboard - Leave blank for all, 0: Quali, 1: Race, 2: PC Time, 3: Speedometer",
 
         "leftMFM": 7,
             "leftMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 7: Status, 8: Map, 9: Opponents",
@@ -178,7 +178,7 @@
             "activeRightMFM_help": "4,5,7,8 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
     
         "activeCentralMFM": "",
-            "activeCentralMFM_help": "0,1,2 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+            "activeCentralMFM_help": "0,1,2,3 - Select which available MFMs to activate in the Dashboard - Leave blank for all, 0: Quali, 1: Race, 2: PC Time, 3: Speedometer",
 
         "leftMFM": 4,
             "leftMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 7: Status, 8: Map, 9: Opponents",
@@ -206,7 +206,7 @@
             "activeRightMFM_help": "4,5,8 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
     
         "activeCentralMFM": "",
-            "activeCentralMFM_help": "0,1,2 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+            "activeCentralMFM_help": "0,1,2,3 - Select which available MFMs to activate in the Dashboard - Leave blank for all, 0: Quali, 1: Race, 2: PC Time, 3: Speedometer",
 
         "leftMFM": 4,
             "leftMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 8: Map, 9: Opponents",

--- a/Lovely-Dashboard_settings.json
+++ b/Lovely-Dashboard_settings.json
@@ -1,0 +1,255 @@
+{
+    "analytics": 1,
+        "analytics_help": "Enable the Dashboard to submit anonymous data regarding the Dashboard usage",
+    
+
+    "yourName": "",
+        "yourName_help": "Your Name (optional)",
+
+    "yourNumber": "",
+        "yourNumber_help": "Your Number (optional)",
+
+    "yourColor": "", 
+        "yourColor_help": "Red, Blue, #2B98FB (default)",
+
+    "yourLogo": "", 
+        "yourLogo_help": "./JavascriptExtensions/lovely-dash-bg.jpg - Image file path relative to the Simhub folder, max 800x270px",
+
+
+    "lfmID": "", 
+        "lfmID_help": "Your LFM ID",
+
+    "pitskillID": "",
+        "pitskillID_help": "Your Pitskill License ID",
+
+
+    "driverName": 1,
+        "driverName_help": "1: F. Lastname, 2: Firstname L., 3: Firstname Lastname",
+
+    "rpmLED": 0,
+        "rpmLED_help": "0: Hide, 1: Show the RPM LED lights",
+
+    "clutchMode": 1,
+        "clutchMode_help": "0: Always Off, 1: Show when engaged, 2: Always On",
+
+    "showFlags": 1,
+        "showFlags_help": "1: Show Flags, 0: Hide Flags",
+
+    "mapType": 1,
+        "mapType_help": "1: Static, 2: Animated - Map type for the map Screen",
+    
+    "mapTypeMFM": 1,
+        "mapTypeMFM_help": "1: Static, 2: Animated - Map type for the Map MFM",
+
+    "mapZoom": 100,
+        "mapZoom_help": "0-100: Map unzoom percentage. The larger the number, the more unzoomed the map gets relative to speed",
+
+    "uiMode": 3,
+        "uiMode_help": "1: Low, 2: Medium, 3: High",
+
+    "uiRadius": 45,
+        "uiRadius_help": "45: Pixel Radius of outer corners, Suggested Min:12, Max:50",
+
+    "nightMode": 1,
+        "nightMode_help": "0: Off, 1: On",
+
+    "tireLapAvg": 2,
+        "tireLapAvg_help": "2: Number of laps to extract AVG Data",
+
+    "tireLapAvgResetKey": "A",
+        "tireLapAvgResetKey_help": "Set a hot-key to reset the AVG Tyre Data. Requires 'Settings>Plugins>Keyboard Input' Plugin enabled in Simhub",
+
+
+    "lapReview": 2,
+        "lapReview_help": "0: Always Off, 1: Only Quali, 2: Always On",
+
+    "lapReviewDelay": 3500,
+        "lapReviewDelay_help": "3500: The time to display the Lap Review Alert in miliseconds",
+
+    "deltaReview": 1,
+        "deltaReview_help": "0: Off, 1:  On - Show or hide the delta and sector review for the previous lap review",
+
+    "deltaReviewDelay": 5000,
+        "deltaReviewDelay_help": "5000: The time to display the Delta & Sector Review Alert in miliseconds",
+
+    "alertView": 1,
+        "alertsView_help": "1: Normal, 2: Mini, 0: Off",
+
+    "alertDelay": 1000,
+        "alertDelay_help": "1000: The time to display the Alerts (TC, ABS etc) in miliseconds",
+
+    "damageAlert": 1,
+        "damageAlert_help": "0: Off, 1: On - Display the damage alert",
+
+    "damageAlertDelay": 7500,
+        "damageAlertDelay_help": "7500: Set the delay of the damage alert in miliseconds",
+
+        
+    "ACC" : {
+
+        "activeLeftMFM": "",
+            "activeLeftMFM_help": "0,1,2,3 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+
+        "activeRightMFM": "",
+            "activeRightMFM_help": "4,5,6,8 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+
+        "activeCentralMFM": "",
+            "activeCentralMFM_help": "0,1,2 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+
+        "leftMFM": 4,
+            "leftMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 6: Damage, 8: Map, 9: Opponents",
+
+        "rightMFM": 0,
+            "rightMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 6: Damage, 8: Map, 9: Opponents",
+            
+        "overlayMFM": 0,
+            "overlayMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 6: Damage, 8: Map, 9: Opponents",
+
+        "centralModule": 0,
+            "centralModule_help": "0: Lap Diff, 1: Nothing, 2: Real Time Clock",
+
+        "fuelModule": 0,
+            "fuelModule_help": "0: Fuel, 1: Fuel Time, 2: Refuel"
+
+    },
+
+    "AC" : {
+
+        "activeLeftMFM": "",
+            "activeLeftMFM_help": "0,1,2,3 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+
+        "activeRightMFM": "",
+            "activeRightMFM_help": "4,5,6,8 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+
+        "activeCentralMFM": "",
+            "activeCentralMFM_help": "0,1,2 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+
+        "leftMFM": 4,
+            "leftMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 6: Damage, 8: Map, 9: Opponents",
+
+        "rightMFM": 0,
+            "rightMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 6: Damage, 8: Map, 9: Opponents",
+
+        "overlayMFM": 0,
+            "overlayMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 6: Damage, 8: Map, 9: Opponents",
+
+        "centralModule": 0,
+            "centralModule_help": "0: Lap Diff, 1: Nothing, 2: Real Time Clock",
+
+        "fuelModule": 0,
+            "fuelModule_help": "0: Fuel, 1: Fuel Time, 2: Refuel"
+
+    },
+
+    "IRacing" : {
+
+        "activeLeftMFM": "",
+            "activeLeftMFM_help": "0,1,2,3 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+
+        "activeRightMFM": "",
+            "activeRightMFM_help": "4,7,8 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+ 
+        "activeCentralMFM": "",
+            "activeCentralMFM_help": "0,1,2 - Select which available MFMs to activate in the Dashboard - Leave blank for all",  
+
+        "leftMFM": 7,
+            "leftMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 7: Status, 8: Map, 9: Opponents",
+
+        "rightMFM": 0,
+            "rightMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 7: Status, 8: Map, 9: Opponents",
+
+        "overlayMFM": 0,
+            "overlayMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 7: Status, 8: Map, 9: Opponents",
+
+        "centralModule": 0,
+            "centralModule_help": "0: Lap Diff, 1: Nothing, 2: Real Time Clock",
+
+        "fuelModule": 0,
+            "fuelModule_help": "0: Fuel, 1: Fuel Time, 2: Refuel"
+    
+    },
+
+    "Automobilista2" : {
+
+        "activeLeftMFM": "",
+            "activeLeftMFM_help": "0,1,2,3 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+
+        "activeRightMFM": "",
+            "activeRightMFM_help": "4,5,7,8 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+    
+        "activeCentralMFM": "",
+            "activeCentralMFM_help": "0,1,2 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+
+        "leftMFM": 4,
+            "leftMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 7: Status, 8: Map, 9: Opponents",
+
+        "rightMFM": 0,
+            "rightMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 7: Status, 8: Map, 9: Opponents",
+
+        "overlayMFM": 0,
+            "overlayMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 7: Status, 8: Map, 9: Opponents",
+
+        "centralModule": 0,
+            "centralModule_help": "0: Lap Diff, 1: Nothing, 2: Real Time Clock",
+
+        "fuelModule": 0,
+            "fuelModule_help": "0: Fuel, 1: Fuel Time, 2: Refuel"
+    
+    },
+
+    "RFactor2" : {
+
+        "activeLeftMFM": "",
+            "activeLeftMFM_help": "0,1,2,3 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+
+        "activeRightMFM": "",
+            "activeRightMFM_help": "4,5,8 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+    
+        "activeCentralMFM": "",
+            "activeCentralMFM_help": "0,1,2 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+
+        "leftMFM": 4,
+            "leftMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 8: Map, 9: Opponents",
+
+        "rightMFM": 0,
+            "rightMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 8: Map, 9: Opponents",
+
+        "overlayMFM": 0,
+            "overlayMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 8: Map, 9: Opponents",
+
+        "centralModule": 0,
+            "centralModule_help": "0: Lap Diff, 1: Nothing, 2: Real Time Clock",
+
+        "fuelModule": 0,
+            "fuelModule_help": "0: Fuel, 1: Fuel Time, 2: Refuel"
+    
+    },
+
+    "F1" : {
+
+        "activeLeftMFM": "",
+            "activeLeftMFM_help": "0,1,2,3 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+
+        "activeRightMFM": "",
+            "activeRightMFM_help": "4,5,6,7,8 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+
+        "activeCentralMFM": "",
+            "activeCentralMFM_help": "0,1,2 - Select which available MFMs to activate in the Dashboard - Leave blank for all",
+            
+        "leftMFM": 4,
+            "leftMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 6: Damage, 7: Status, 8: Map, 9: Opponents",
+
+        "rightMFM": 0,
+            "rightMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 6: Damage, 7: Status, 8: Map, 9: Opponents",
+
+        "overlayMFM": 0,
+            "overlayMFM_help": "0: Lap Times, 1: Sectors, 2: Relative, 3: Standings, 4: Tires, 5: Tire AVG, 6: Damage, 7: Status, 8: Map, 9: Opponents",
+
+        "centralModule": 0,
+            "centralModule_help": "0: Lap Diff, 1: Nothing, 2: Real Time Clock",
+
+        "fuelModule": 0,
+            "fuelModule_help": "0: Fuel, 1: Fuel Time, 2: Refuel"
+
+    }
+}


### PR DESCRIPTION
I'm not sure where to put the new Lovely-Dashboard_settings.json so I put it in the root folder for example in this pull request

I just replicate the behavior of the left and right MFM to be able to choose between the pool of centers MFM we are able to cycle with the keybind

I'm not sure how to call it so it's `activeCentralMFM` but maybe it should be `activeCentralModule`

```
"activeCentralMFM": "",
            "activeCentralMFM_help": "0,1,2,3 - Select which available MFMs to activate in the Dashboard - Leave blank for all, 0: Quali, 1: Race, 2: PC Time, 3: Speedometer",

```